### PR TITLE
Update maths.py for BUG: Shape miscalculation in np.squeeze(X) in dot_likelihood() (pymdp.maths.py)

### DIFF
--- a/pymdp/maths.py
+++ b/pymdp/maths.py
@@ -242,7 +242,7 @@ def dot_likelihood(A,obs):
     s[0] = obs.shape[0]
     X = A * obs.reshape(tuple(s))
     X = np.sum(X, axis=0, keepdims=True)
-    LL = np.squeeze(X)
+    LL = np.squeeze(X, axis=0)
 
     # check to see if `LL` is a scalar
     if np.prod(LL.shape) <= 1.0:


### PR DESCRIPTION
update line 225 in maths.py to make it LL = np.squeeze(X, axis=0)

this is for the bug of

BUG: Shape miscalculation in np.squeeze(X) in dot_likelihood() (pymdp.maths.py)

https://github.com/infer-actively/pymdp/issues/171